### PR TITLE
fix nginx config

### DIFF
--- a/infra/nginx.conf.sh
+++ b/infra/nginx.conf.sh
@@ -31,13 +31,13 @@ http {
     listen 80;
     server_name _;
     location /contracts {
-      proxy_pass http://${LEDGER_IP_PORT}/;
+      proxy_pass http://${LEDGER_IP_PORT};
     }
     location /command {
-      proxy_pass http://${LEDGER_IP_PORT}/;
+      proxy_pass http://${LEDGER_IP_PORT};
     }
     location /parties {
-      proxy_pass http://${LEDGER_IP_PORT}/;
+      proxy_pass http://${LEDGER_IP_PORT};
     }
 
     root /app/ui;


### PR DESCRIPTION
It turns out that
```
    location /contracts {
       proxy_pass http://${LEDGER_IP_PORT}/;
    }
```
is asking nginx to _replace_ `/contracts` with `/` whereas
```
    location /contracts {
       proxy_pass http://${LEDGER_IP_PORT};
    }
```
keeps the entire path of the URL unchanged.