### PR TITLE
fix redeploy issue

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -213,7 +213,7 @@ resource "google_compute_address" "frontend" {
 
 resource "google_compute_target_instance" "frontend" {
   name     = "frontend"
-  instance = "${google_compute_instance.proxy.self_link}"
+  instance = "${google_compute_instance.proxy.name}"
   zone     = "us-east4-a"
 }
 


### PR DESCRIPTION
When Terraform tries to deploy a new version of the UI, it detects that
it needs to recreate the proxy machine (good), and that means it has to
recreate the target instance (good), and that means it has to change
the forwarding rules to point to the new target instance (seems good,
but actually bad).

Because Terraform beloeves it can change the forwarding rules in-place
rather than having to destroy them and create new ones, the sequence of
operations it computes is:

- destroy target instance
- destroy instance
- create isntance
- create target instance
- update forwarding rules

However, the first step fails on the grounds that the target instance is
still used by the forwarding rules at that point.

As a workaround, we make the target instance depend on the name of the
instance rather than its ID. As the name doesn't change when the
jinstance gets destroyed and recreated, and, crucially, doesn't require
the instance to actually exist, upgrading the UI no longer requires
destroying and recreating the target instance, which resolves the issue.