### PR TITLE
remove daml.dar from sandbox cli args

### DIFF
--- a/infra/sandbox.docker
+++ b/infra/sandbox.docker
@@ -15,4 +15,4 @@ RUN curl https://get.daml.com | sh -s 0.13.32
 
 WORKDIR /app
 
-ENTRYPOINT ["java", "-jar", "/app/sandbox.jar", "--eager-package-loading", "/app/daml.dar", "--ledgerid", "DAVL"]
+ENTRYPOINT ["java", "-jar", "/app/sandbox.jar", "--ledgerid", "DAVL"]


### PR DESCRIPTION
It's now loaded as `/app/released/20191107-2103-5f19ce-v3.dar`, and loaded as an extra step. The sandbox now crashes at startup.