### PR TITLE
add load balancers to do TLS termination

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -9,12 +9,13 @@ terraform {
 locals {
   sandbox = "201911131644-d67d39"
   json    = "201911072118-6e3b95"
-  ui      = "201911131532-e57a97"
+  ui      = "201911141701-5a2df5"
 }
 
 provider "google" {
   project = "da-dev-pinacolada"
   region  = "us-east4"
+  zone    = "us-east4-a"
 }
 
 # Network created by the security team. Allows all traffic from offices and
@@ -25,15 +26,6 @@ data "google_compute_network" "network" {
 
 data "google_compute_subnetwork" "subnet" {
   name = "da-gcp-pinacolada-subnet-1"
-}
-
-resource "google_compute_firewall" "allow-external-ssh" {
-  name    = "allow-external-ssh"
-  network = "${data.google_compute_network.network.self_link}"
-  allow {
-    protocol = "tcp"
-    ports    = ["22"]
-  }
 }
 
 resource "google_compute_firewall" "allow-internal" {
@@ -51,10 +43,20 @@ resource "google_compute_firewall" "allow-internal" {
   source_ranges = ["${data.google_compute_subnetwork.subnet.ip_cidr_range}"]
 }
 
+resource "google_compute_firewall" "allow-http-load-balancers" {
+  name    = "allow-lb"
+  network = "${data.google_compute_network.network.self_link}"
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "8080", "8081"]
+  }
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["http-enabled"]
+}
+
 resource "google_compute_instance" "db" {
   name         = "db"
   machine_type = "n1-standard-2"
-  zone         = "us-east4-a"
 
   boot_disk {
     initialize_params {
@@ -90,7 +92,6 @@ STARTUP
 resource "google_compute_instance" "ledger" {
   name         = "ledger"
   machine_type = "n1-standard-2"
-  zone         = "us-east4-a"
 
   boot_disk {
     initialize_params {
@@ -162,7 +163,6 @@ STARTUP
 resource "google_compute_instance" "proxy" {
   name         = "proxy"
   machine_type = "n1-standard-2"
-  zone         = "us-east4-a"
 
   boot_disk {
     initialize_params {
@@ -199,38 +199,208 @@ gcloud auth configure-docker --quiet
 # The UI currently does not support signing up, so we add a running Navigator
 # to our setup. It will be served on 8080, so we also need to expose that port.
 # Added -p 8080:8080 and -e NAVIGATOR_IP_PORT=...
-docker run -p 8080:8080 -e NAVIGATOR_IP_PORT=${google_compute_instance.ledger.network_interface.0.network_ip}:8080 -p 80:80 -e LEDGER_IP_PORT=${google_compute_instance.ledger.network_interface.0.network_ip}:7575 gcr.io/da-dev-pinacolada/ui:${local.ui}
+docker run -p 8081:8081 -p 8080:8080 -e NAVIGATOR_IP_PORT=${google_compute_instance.ledger.network_interface.0.network_ip}:8080 -p 80:80 -e LEDGER_IP_PORT=${google_compute_instance.ledger.network_interface.0.network_ip}:7575 gcr.io/da-dev-pinacolada/ui:${local.ui}
 # </workaround>
 
 
 STARTUP
 }
 
-resource "google_compute_address" "frontend" {
-  name   = "frontend"
-  region = "us-east4"
+resource "google_compute_address" "proxy" {
+  name         = "proxy"
+  region       = "us-east4"
+  network_tier = "STANDARD"
 }
 
-resource "google_compute_target_instance" "frontend" {
-  name     = "frontend"
-  instance = "${google_compute_instance.proxy.name}"
-  zone     = "us-east4-a"
+// Networking rules need to target a group, so we create on for the forntend
+// machine.
+resource "google_compute_instance_group" "frontend" {
+  name      = "frontend"
+  instances = ["${google_compute_instance.proxy.self_link}"]
+  named_port {
+    name = "http"
+    port = "8081"
+  }
+  named_port {
+    name = "https"
+    port = "80"
+  }
+  named_port {
+    name = "navigator"
+    port = "8080"
+  }
 }
 
-resource "google_compute_forwarding_rule" "frontend-http" {
-  name       = "frontend-http"
-  target     = "${google_compute_target_instance.frontend.self_link}"
-  ip_address = "${google_compute_address.frontend.address}"
-  port_range = "80"
+// The load balancers are created outside our network, and therefore do not
+// inherit the security rules defined by the security team as firewall rules on
+// the network. We still want (for now at least) the same level of isolation.
+resource "google_compute_security_policy" "only-offices-and-vpns" {
+  name = "only-offices-and-vpns"
+
+  rule {
+    action   = "deny(403)"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "Default: deny all"
+  }
+
+  rule {
+    action   = "allow"
+    priority = 998
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = [
+          "188.142.210.213",
+          "49.255.4.210",
+          "172.85.43.2",
+          "151.237.232.154",
+          "146.4.45.122"
+        ]
+      }
+    }
+    description = "Allow offices"
+  }
+
+  // There is a limit of 5 ranges per rule.
+  rule {
+    action   = "allow"
+    priority = 997
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = [
+          "52.204.127.83",
+          "35.194.81.56",
+          "35.189.40.124",
+          "35.198.147.95",
+          "52.73.38.90",
+        ]
+      }
+    }
+    description = "Allow first five VPNs"
+  }
+
+  rule {
+    action   = "allow"
+    priority = 999
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = [
+          "34.92.190.230"
+        ]
+      }
+    }
+    description = "Allow last VPN"
+  }
 }
 
+// All our networking rules target the same machine so we use the same health
+// check. Note: this always checks port 80 on the proxy machine.
+resource "google_compute_http_health_check" "frontend" {
+  name               = "health-check"
+  request_path       = "/"
+  check_interval_sec = 20
+  timeout_sec        = 3
+}
+
+// FRONTEND: forward connections on port 80 to frontend machine port 8081, so
+// they get redirected by nginx to HTTPS on port 443.
+resource "google_compute_forwarding_rule" "frontend" {
+  name         = "frontend"
+  target       = "${google_compute_target_http_proxy.frontend.self_link}"
+  ip_address   = "${google_compute_address.proxy.address}"
+  port_range   = "80"
+  network_tier = "STANDARD"
+}
+
+resource "google_compute_target_http_proxy" "frontend" {
+  name    = "frontend"
+  url_map = "${google_compute_url_map.frontend.self_link}"
+}
+
+resource "google_compute_url_map" "frontend" {
+  name            = "frontend"
+  default_service = "${google_compute_backend_service.frontend.self_link}"
+}
+
+resource "google_compute_backend_service" "frontend" {
+  name            = "frontend"
+  health_checks   = ["${google_compute_http_health_check.frontend.self_link}"]
+  security_policy = "${google_compute_security_policy.only-offices-and-vpns.self_link}"
+  port_name       = "http"
+  backend {
+    group = "${google_compute_instance_group.frontend.self_link}"
+  }
+}
+
+// UI: serve application; redirect connections to port 443 of the external IP
+// address to port 80 of the machine (after TLS termination)
+resource "google_compute_forwarding_rule" "ui" {
+  name         = "ui"
+  target       = "${google_compute_target_https_proxy.ui.self_link}"
+  ip_address   = "${google_compute_address.proxy.address}"
+  port_range   = "443"
+  network_tier = "STANDARD"
+}
+
+resource "google_compute_target_https_proxy" "ui" {
+  name             = "ui"
+  url_map          = "${google_compute_url_map.ui.self_link}"
+  ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/da-dev-pinacolada/global/sslCertificates/da-ext-wildcard"]
+}
+
+resource "google_compute_url_map" "ui" {
+  name            = "ui"
+  default_service = "${google_compute_backend_service.ui.self_link}"
+}
+
+resource "google_compute_backend_service" "ui" {
+  name            = "ui"
+  health_checks   = ["${google_compute_http_health_check.frontend.self_link}"]
+  security_policy = "${google_compute_security_policy.only-offices-and-vpns.self_link}"
+  port_name       = "https"
+  backend {
+    group = "${google_compute_instance_group.frontend.self_link}"
+  }
+}
+
+// Navigator: serve on 8080. Cannot serve as HTTPS as GCP restricts that to
+// 443.
 resource "google_compute_forwarding_rule" "navigator" {
-  name       = "navigator"
-  target     = "${google_compute_target_instance.frontend.self_link}"
-  ip_address = "${google_compute_address.frontend.address}"
-  port_range = "8080"
+  name         = "navigator"
+  target       = "${google_compute_target_http_proxy.navigator.self_link}"
+  ip_address   = "${google_compute_address.proxy.address}"
+  port_range   = "8080"
+  network_tier = "STANDARD"
 }
 
-output "frontend-address" {
-  value = "${google_compute_address.frontend.address}"
+resource "google_compute_target_http_proxy" "navigator" {
+  name    = "navigator"
+  url_map = "${google_compute_url_map.navigator.self_link}"
+}
+
+resource "google_compute_url_map" "navigator" {
+  name            = "navigator"
+  default_service = "${google_compute_backend_service.navigator.self_link}"
+}
+
+resource "google_compute_backend_service" "navigator" {
+  name            = "navigator"
+  health_checks   = ["${google_compute_http_health_check.frontend.self_link}"]
+  security_policy = "${google_compute_security_policy.only-offices-and-vpns.self_link}"
+  port_name       = "navigator"
+  backend {
+    group = "${google_compute_instance_group.frontend.self_link}"
+  }
+}
+
+output "proxy-ip" {
+  value = "${google_compute_address.proxy.address}"
 }


### PR DESCRIPTION
Summary:
- Deploy latest (#54) frontend
- Remove "allow external SSH" rule per Edward's request
- Add HTTP load balancers so one of them can do TLS termination

*This has already been deployed.*

Notes:
- Because we started with fairly restrictive network rules, we have to explicitly add a rule to allow the load balancers to connect to our frontend machine.
- Because the load balancers themselves live outside our network, they are not affected by our default firewall rules and therefore act as a bridge that would let anyone visit our budding application. As it is not ready for prime time yet, I had to add similar restrictions, which for load balancers is done with "security policy" rather than "firewall rule", but in our case they're essentially the same: a list of allowed IP addresses and a default rule saying deny all the rest. The main difference is that denied requests will get a 403 HTTP response rather than just hanging.
- The IP address had to change because the one we had was "premium, regional" and GCP only supports load balancers for either "standard, regional" or "premium, global".
- I wanted to serve navigator on HTTPS too, but GCP has weird, arbitrary restrictions on which ports their load balancers can receive traffic on and the HTTPS one is limited to a single one (443), which means this would require a separate DNS name. As exposing a full-blown navigator should be a temporary workaround anyway, I have decided to keep it on HTTP for the time being.