### PR TITLE
Remove ui/build.sh and call yarn build directly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,8 +129,8 @@ jobs:
               echo "Building ui image version $UI_TAG..."
               UI_IMAGE=gcr.io/da-dev-pinacolada/ui:$UI_TAG
               DOCKER_DIR=$(mktemp -d)
-              (cd ui && ./build.sh)
-              cp -r ui/release $DOCKER_DIR/ui
+              (cd ui && yarn build)
+              cp -r ui/build $DOCKER_DIR/ui
               cp infra/nginx.conf.sh $DOCKER_DIR/nginx.conf.sh
               docker build -t $UI_IMAGE -f infra/nginx.docker $DOCKER_DIR
               docker push $UI_IMAGE

--- a/ui/build.sh
+++ b/ui/build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-yarn install
-yarn build
-mv build release


### PR DESCRIPTION
I don't see any necessity for this indirection right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/62)
<!-- Reviewable:end -->
