### PR TITLE
Remove ui dependency on json-type-validation

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@digitalasset/daml-json-types": "0.0.1",
-    "@mojotech/json-type-validation": "^3.1.0",
     "@types/jest": "24.0.18",
     "@types/node": "12.7.12",
     "@types/react": "16.9.5",


### PR DESCRIPTION
daml-json-types already depends on json-type-validation already depends on
json-type-validation and is the reason why we actully need the latter. This
way, we should avoid running into situations where we depend on two different
version of json-type-validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/63)
<!-- Reviewable:end -->
