### PR TITLE
Make packageId field mandatory in TemplateId

### DIFF
--- a/daml-json-types/src/index.ts
+++ b/daml-json-types/src/index.ts
@@ -13,7 +13,7 @@ export interface Serializable<T> {
  * Identifier of a DAML template.
  */
 export type TemplateId = {
-  packageId?: string;
+  packageId: string;
   moduleName: string;
   entityName: string;
 }
@@ -23,7 +23,7 @@ export type TemplateId = {
  */
 const TemplateId: Serializable<TemplateId> = {
   decoder: () => jtv.object({
-    packageId: jtv.optional(jtv.string()),
+    packageId: jtv.string(),
     moduleName: jtv.string(),
     entityName: jtv.string(),
   })


### PR DESCRIPTION
The `daml-json-types` library is intended to be a target for codegen. There's
no point in leaving out the package id, when we actually know it.
The JSON API also seems to always send the package id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/66)
<!-- Reviewable:end -->
