### PR TITLE
Fix typo in daml-json-types

### DIFF
--- a/daml-json-types/src/index.ts
+++ b/daml-json-types/src/index.ts
@@ -100,7 +100,7 @@ export type Decimal = string;
 /**
  * Companion object of the `Decimal` type.
  */
-export const Decimal: Serializable<Int> = {
+export const Decimal: Serializable<Decimal> = {
   decoder: jtv.string,
 }
 


### PR DESCRIPTION
Actually, it's copy&paste gone wrong. :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/70)
<!-- Reviewable:end -->
