### PR TITLE
Support useQuery in "fetch everything" mode

### DIFF
--- a/ui/src/app/damlReducer.ts
+++ b/ui/src/app/damlReducer.ts
@@ -116,10 +116,12 @@ export const reducer = (state = initialState as State, action: Action): State =>
   return state;
 }
 
+const emptyQueryFactory = <T extends {}>(): Query<T> => ({} as Query<T>);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const useQuery = <T>(template: Template<T>, queryFactory: () => Query<T>, queryDeps: readonly any[] | undefined): QueryStore.Entry<T> => {
+export const useQuery = <T>(template: Template<T>, queryFactory: () => Query<T> = emptyQueryFactory, queryDeps?: readonly any[]): QueryStore.Entry<T> => {
   const dispatch = useDispatch();
-  const query = useMemo(queryFactory, queryDeps)
+  const query = useMemo(queryFactory, queryDeps);
   const contracts = useSelector((state: root.RootState) => LedgerStore.getQueryResult(getLedgerStore(state), template, query));
   useEffect(() => {
     if (contracts === undefined) {


### PR DESCRIPTION
Support the use of `useQuery` without a query, which will fetch all contracts
of a given template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/82)
<!-- Reviewable:end -->
