### PR TITLE
Rename Contract type to CreateEvent and move it to daml-ledger-fetch

### DIFF
--- a/daml-json-types/src/index.ts
+++ b/daml-json-types/src/index.ts
@@ -21,21 +21,10 @@ export type TemplateId = {
 }
 
 /**
- * Companion object of the `TemplateId` type.
- */
-export const TemplateId: Serializable<TemplateId> = {
-  decoder: () => jtv.object({
-    packageId: jtv.string(),
-    moduleName: jtv.string(),
-    entityName: jtv.string(),
-  })
-}
-
-/**
  * Interface for objects representing DAML templates. It is similar to the
  * `Template` type class in DAML.
  */
-export interface Template<T extends {}> extends Serializable<T> {
+export interface Template<T> extends Serializable<T> {
   templateId: TemplateId;
   Archive: Choice<T, {}>;
 }
@@ -69,7 +58,7 @@ export const lookupTemplate = (templateId: TemplateId): Template<object> => {
   const templateIdStr = templateIdToString(templateId);
   const template = registeredTemplates[templateIdStr];
   if (template === undefined) {
-    throw Error(`Trying to look up template ${templateIdStr}`);
+    throw Error(`Trying to look up template ${templateIdStr}.`);
   }
   return template;
 }
@@ -232,51 +221,3 @@ export const TextMap = <T>(t: Serializable<T>): Serializable<TextMap<T>> => ({
 // TODO(MH): `Numeric` type.
 
 // TODO(MH): `Map` type.
-
-/**
- * Type for a contract instance of a template type `T`. Besides the contract
- * payload it also contains meta data like the contract id, signatories, etc.
- *
- * Contract keys are not yet properly supported.
- */
-export type Contract<T> = {
-  templateId: TemplateId;
-  contractId: ContractId<T>;
-  signatories: Party[];
-  observers: Party[];
-  agreementText: Text;
-  key: unknown;
-  argument: T;
-  witnessParties: Party[];
-  workflowId?: string;
-}
-
-/**
- * Companion object of the `Contract` type.
- */
-export const Contract = <T extends {}>(t: Template<T>): Serializable<Contract<T>> => ({
-  decoder: () => jtv.object({
-    templateId: TemplateId.decoder(),
-    contractId: ContractId(t).decoder(),
-    signatories: jtv.array(Party.decoder()),
-    observers: jtv.array(Party.decoder()),
-    agreementText: Text.decoder(),
-    key: jtv.unknownJson(),
-    argument: t.decoder(),
-    witnessParties: jtv.array(Party.decoder()),
-    workflowId: jtv.optional(jtv.string()),
-  }),
-});
-
-/**
- * Type for queries against the `/contract/search` endpoint of the JSON API.
- * `Query<T>` is the type of queries that are valid when searching for
- * contracts of template type `T`.
- *
- * Comparison queries are not yet supported.
- *
- * NB: This type is heavily related to the `DeepPartial` type that can be found
- * in the TypeScript community.
- */
-export type Query<T> = T extends object ? {[K in keyof T]?: Query<T[K]>} : T;
-// TODO(MH): Support comparison queries.

--- a/daml-ledger-fetch/src/index.ts
+++ b/daml-ledger-fetch/src/index.ts
@@ -1,9 +1,78 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-import { Choice, Contract, ContractId, Party, Template, Query, TemplateId, Serializable } from '@digitalasset/daml-json-types';
+import { Choice, ContractId, List, Party, Template, TemplateId, Text, lookupTemplate } from '@digitalasset/daml-json-types';
 import * as jtv from '@mojotech/json-type-validation';
 import fetch from 'cross-fetch';
+
+export type CreateEvent<T> = {
+  templateId: TemplateId;
+  contractId: ContractId<T>;
+  signatories: List<Party>;
+  observers: List<Party>;
+  agreementText: Text;
+  key: unknown;
+  argument: T;
+  witnessParties: List<Party>;
+  workflowId?: string;
+}
+
+export type ArchiveEvent<T> = {
+  templateId: TemplateId;
+  contractId: ContractId<T>;
+  witnessParties: List<Party>;
+}
+
+export type Event<T> =
+  | { created: CreateEvent<T> }
+  | { archived: ArchiveEvent<T> }
+
+const decodeTemplateId = (): jtv.Decoder<TemplateId> => jtv.object({
+  packageId: jtv.string(),
+  moduleName: jtv.string(),
+  entityName: jtv.string(),
+});
+
+const decodeCreateEvent = <T>(t: Template<T>): jtv.Decoder<CreateEvent<T>> => jtv.object({
+  templateId: decodeTemplateId(),
+  contractId: ContractId(t).decoder(),
+  signatories: List(Party).decoder(),
+  observers: List(Party).decoder(),
+  agreementText: Text.decoder(),
+  key: jtv.unknownJson(),
+  argument: t.decoder(),
+  witnessParties: List(Party).decoder(),
+  workflowId: jtv.optional(jtv.string()),
+});
+
+const decodeCreateEventUnknown = (): jtv.Decoder<CreateEvent<unknown>> =>
+  jtv.valueAt(['templateId'], decodeTemplateId()).andThen((templateId) =>
+    decodeCreateEvent(lookupTemplate(templateId))
+  );
+
+const decodeArchiveEventUnknown = (): jtv.Decoder<ArchiveEvent<unknown>> => jtv.object({
+  templateId: decodeTemplateId(),
+  contractId: ContractId({decoder: jtv.unknownJson}).decoder(),
+  witnessParties: List(Party).decoder(),
+});
+
+const decodeEventUnknown = (): jtv.Decoder<Event<unknown>> => jtv.oneOf<Event<unknown>>(
+  jtv.object({created: decodeCreateEventUnknown()}),
+  jtv.object({archived: decodeArchiveEventUnknown()}),
+);
+
+/**
+ * Type for queries against the `/contract/search` endpoint of the JSON API.
+ * `Query<T>` is the type of queries that are valid when searching for
+ * contracts of template type `T`.
+ *
+ * Comparison queries are not yet supported.
+ *
+ * NB: This type is heavily related to the `DeepPartial` type that can be found
+ * in the TypeScript community.
+ */
+export type Query<T> = T extends object ? {[K in keyof T]?: Query<T[K]>} : T;
+// TODO(MH): Support comparison queries.
+
 
 type LedgerResponse = {
   status: number;
@@ -13,47 +82,6 @@ type LedgerResponse = {
 type LedgerError = {
   status: number;
   errors: string[];
-}
-
-export type CreatedEvent = {
-  created: Contract<object>;
-}
-
-export type ArchivedEvent = {
-  archived: {
-    templateId: TemplateId;
-    contractId: ContractId<object>;
-    witnessParties: Party[];
-  };
-}
-
-export type Event = CreatedEvent | ArchivedEvent;
-
-// FIXME(MH): The cast below is a gross hack relying on the fact that
-// `Contract` will only use the `decoder` field of its argument. We should
-// instead provide something like a proper `AnyContract` in `daml-json-types`.
-const AnyTemplate: Template<object> = {
-  decoder: () => jtv.object({}),
-} as Template<object>;
-
-const CreatedEvent: Serializable<CreatedEvent> = {
-  decoder: () => jtv.object({
-    created: Contract(AnyTemplate).decoder(),
-  }),
-};
-
-const ArchivedEvent: Serializable<ArchivedEvent> = {
-  decoder: () => jtv.object({
-    archived: jtv.object({
-      templateId: TemplateId.decoder(),
-      contractId: ContractId(AnyTemplate).decoder(),
-      witnessParties: jtv.array(Party.decoder()),
-    }),
-  }),
-};
-
-const Event: Serializable<Event> = {
-  decoder: () => jtv.oneOf<Event>(CreatedEvent.decoder(), ArchivedEvent.decoder()),
 }
 
 /**
@@ -103,17 +131,17 @@ class Ledger {
    * https://github.com/digital-asset/daml/blob/master/docs/source/json-api/search-query-language.rst
    * for a description of the query language.
    */
-  async query<T>(template: Template<T>, query: Query<T>): Promise<Contract<T>[]> {
+  async query<T>(template: Template<T>, query: Query<T>): Promise<CreateEvent<T>[]> {
     const payload = {"%templates": [template.templateId]};
     Object.assign(payload, query);
     const json = await this.submit('contracts/search', payload);
-    return jtv.Result.withException(jtv.array(Contract(template).decoder()).run(json));
+    return jtv.Result.withException(jtv.array(decodeCreateEvent(template)).run(json));
   }
 
   /**
    * Retrieve all contracts for a given template.
    */
-  async fetchAll<T>(template: Template<T>): Promise<Contract<T>[]> {
+  async fetchAll<T>(template: Template<T>): Promise<CreateEvent<T>[]> {
     return this.query(template, {} as Query<T>);
   }
 
@@ -121,7 +149,7 @@ class Ledger {
    * Mimic DAML's `lookupByKey`. The `key` must be a formulation of the
    * contract key as a query.
    */
-  async pseudoLookupByKey<T>(template: Template<T>, key: Query<T>): Promise<Contract<T> | undefined> {
+  async pseudoLookupByKey<T>(template: Template<T>, key: Query<T>): Promise<CreateEvent<T> | undefined> {
     const contracts = await this.query(template, key);
     if (contracts.length > 1) {
       throw Error("pseudoLookupByKey: query returned multiple contracts");
@@ -133,7 +161,7 @@ class Ledger {
    * Mimic DAML's `fetchByKey`. The `key` must be a formulation of the
    * contract key as a query.
    */
-  async pseudoFetchByKey<T>(template: Template<T>, key: Query<T>): Promise<Contract<T>> {
+  async pseudoFetchByKey<T>(template: Template<T>, key: Query<T>): Promise<CreateEvent<T>> {
     const contract = await this.pseudoLookupByKey(template, key);
     if (contract === undefined) {
       throw Error("pseudoFetchByKey: query returned no contract");
@@ -144,19 +172,19 @@ class Ledger {
   /**
    * Create a contract for a given template.
    */
-  async create<T>(template: Template<T>, argument: T): Promise<Contract<T>> {
+  async create<T>(template: Template<T>, argument: T): Promise<CreateEvent<T>> {
     const payload = {
       templateId: template.templateId,
       argument,
     }
     const json = await this.submit('command/create', payload);
-    return jtv.Result.withException(Contract(template).decoder().run(json));
+    return jtv.Result.withException(decodeCreateEvent(template).run(json));
   }
 
   /**
    * Exercise a choice on a contract.
    */
-  async exercise<T, C>(choice: Choice<T, C>, contractId: ContractId<T>, argument: C): Promise<Event[]> {
+  async exercise<T, C>(choice: Choice<T, C>, contractId: ContractId<T>, argument: C): Promise<Event<unknown>[]> {
     const payload = {
       templateId: choice.template().templateId,
       contractId,
@@ -164,14 +192,14 @@ class Ledger {
       argument,
     };
     const json = await this.submit('command/exercise', payload);
-    return jtv.Result.withException(jtv.array(Event.decoder()).run(json));
+    return jtv.Result.withException(jtv.array(decodeEventUnknown()).run(json));
   }
 
   /**
    * Mimic DAML's `exerciseByKey`. The `key` must be a formulation of the
    * contract key as a query.
    */
-  async pseudoExerciseByKey<T, C>(choice: Choice<T, C>, key: Query<T>, argument: C): Promise<Event[]> {
+  async pseudoExerciseByKey<T, C>(choice: Choice<T, C>, key: Query<T>, argument: C): Promise<Event<unknown>[]> {
     const contract = await this.pseudoFetchByKey(choice.template(), key);
     return this.exercise(choice, contract.contractId, argument);
   }
@@ -192,4 +220,3 @@ class Ledger {
 }
 
 export default Ledger;
-

--- a/ui/src/daml-react-hooks/hooks.ts
+++ b/ui/src/daml-react-hooks/hooks.ts
@@ -1,5 +1,5 @@
-import { Template, Query, Contract, Choice, ContractId, lookupTemplate } from "@digitalasset/daml-json-types";
-import { Event } from '@digitalasset/daml-ledger-fetch';
+import { Template, Choice, ContractId, lookupTemplate } from "@digitalasset/daml-json-types";
+import { Event, Query, CreateEvent } from '@digitalasset/daml-ledger-fetch';
 import { useEffect, useMemo, useState, useContext } from "react";
 import * as LedgerStore from './ledgerStore';
 import * as TemplateStore from './templateStore';
@@ -28,7 +28,7 @@ const loadQuery = async <T extends {}>(state: DamlLedgerState, template: Templat
 const emptyQueryFactory = <T extends {}>(): Query<T> => ({} as Query<T>);
 
 export type QueryResult<T> = {
-  contracts: Contract<T>[];
+  contracts: CreateEvent<T>[];
   loading: boolean;
 }
 
@@ -48,7 +48,7 @@ export const useQuery = <T>(template: Template<T>, queryFactory: () => Query<T> 
 }
 
 export type FetchResult<T> = {
-  contract: Contract<T> | null;
+  contract: CreateEvent<T> | null;
   loading: boolean;
 }
 
@@ -77,7 +77,7 @@ const reloadTemplate = async <T extends {}>(state: DamlLedgerState, template: Te
   }
 }
 
-const reloadEvents = async (state: DamlLedgerState, events: Event[]) => {
+const reloadEvents = async (state: DamlLedgerState, events: Event<unknown>[]) => {
   // TODO(MH): This is a sledge hammer approach. We completely reload every
   // single template that has been touched by the events. A future optimization
   // would be to remove the archived templates from their tables and add the

--- a/ui/src/daml-react-hooks/ledgerStore.ts
+++ b/ui/src/daml-react-hooks/ledgerStore.ts
@@ -1,5 +1,6 @@
 import * as immutable from 'immutable';
-import { Query, Contract, Template } from '@digitalasset/daml-json-types';
+import { Template } from '@digitalasset/daml-json-types';
+import { CreateEvent, Query } from '@digitalasset/daml-ledger-fetch';
 import * as TemplateStore from './templateStore';
 
 export type Store = {
@@ -26,7 +27,7 @@ export const setQueryLoading = <T extends {}>(store: Store, template: Template<T
     TemplateStore.setQueryLoading(templateStore, query))
 });
 
-export const setQueryResult = <T extends {}>(store: Store, template: Template<T>, query: Query<T>, contracts: Contract<T>[]): Store => ({
+export const setQueryResult = <T extends {}>(store: Store, template: Template<T>, query: Query<T>, contracts: CreateEvent<T>[]): Store => ({
   ...store,
   templateStores: store.templateStores.update(template, (templateStore = TemplateStore.empty()) =>
     TemplateStore.setQueryResult(templateStore, query, contracts))

--- a/ui/src/daml-react-hooks/reducer.ts
+++ b/ui/src/daml-react-hooks/reducer.ts
@@ -1,4 +1,5 @@
-import { Template, Query, Contract } from "@digitalasset/daml-json-types";
+import { Template } from "@digitalasset/daml-json-types";
+import { CreateEvent, Query } from '@digitalasset/daml-ledger-fetch';
 import * as LedgerStore from './ledgerStore';
 
 const SET_QUERY_LOADING = 'SET_QUERY_LOADING';
@@ -14,7 +15,7 @@ type SetQueryResultAction<T> = {
   type: typeof SET_QUERY_RESULT;
   template: Template<T>;
   query: Query<T>;
-  contracts: Contract<T>[];
+  contracts: CreateEvent<T>[];
 }
 
 export type Action = SetQueryLoadingAction<object> | SetQueryResultAction<object>;
@@ -25,7 +26,7 @@ export const setQueryLoading = <T>(template: Template<T>, query: Query<T>): SetQ
   query,
 });
 
-export const setQueryResult = <T>(template: Template<T>, query: Query<T>, contracts: Contract<T>[]): SetQueryResultAction<T> => ({
+export const setQueryResult = <T>(template: Template<T>, query: Query<T>, contracts: CreateEvent<T>[]): SetQueryResultAction<T> => ({
   type: SET_QUERY_RESULT,
   template,
   query,

--- a/ui/src/daml-react-hooks/templateStore.ts
+++ b/ui/src/daml-react-hooks/templateStore.ts
@@ -1,8 +1,8 @@
 import * as immutable from 'immutable';
-import { Query, Contract } from '@digitalasset/daml-json-types';
+import { CreateEvent, Query } from '@digitalasset/daml-ledger-fetch';
 
 export type QueryResult<T> = {
-  contracts: Contract<T>[];
+  contracts: CreateEvent<T>[];
   loading: boolean;
 }
 
@@ -28,7 +28,7 @@ export const setQueryLoading = <T>(store: Store<T>, query: Query<T>): Store<T> =
   queryResults: store.queryResults.update(query, (res = emptyQueryResult()) => ({...res, loading: true})),
 })
 
-export const setQueryResult = <T>(store: Store<T>, query: Query<T>, contracts: Contract<T>[]): Store<T> => ({
+export const setQueryResult = <T>(store: Store<T>, query: Query<T>, contracts: CreateEvent<T>[]): Store<T> => ({
   ...store,
   queryResults: store.queryResults.set(query, {contracts, loading: false})
 });

--- a/ui/src/utils/employee.ts
+++ b/ui/src/utils/employee.ts
@@ -1,4 +1,5 @@
-import { Party, Contract } from '@digitalasset/daml-json-types';
+import { Party } from '@digitalasset/daml-json-types';
+import { CreateEvent } from '@digitalasset/daml-ledger-fetch';
 import { ordString, Ord, contramap } from 'fp-ts/lib/Ord';
 import * as v3 from '../daml/edb5e54da44bc80782890de3fc58edb5cc227a6b7e8c467536f8674b0bf4deb7/DAVL';
 
@@ -11,7 +12,7 @@ export type EmployeeSummary = {
 export const ordEmployeeSummaryOnName: Ord<EmployeeSummary> =
   contramap((summary: EmployeeSummary) => summary.employee)(ordString);
 
-export const prettyEmployeeSummaries = (allocations: Contract<v3.EmployeeVacationAllocation>[]): EmployeeSummary[] => {
+export const prettyEmployeeSummaries = (allocations: CreateEvent<v3.EmployeeVacationAllocation>[]): EmployeeSummary[] => {
   const staff = allocations.map(({argument: {employeeRole: {employee, boss}, remainingDays}}) =>
     ({employee, boss, remainingVacationDays: remainingDays}));
   staff.sort(ordEmployeeSummaryOnName.compare);

--- a/ui/src/utils/vacation.ts
+++ b/ui/src/utils/vacation.ts
@@ -1,4 +1,5 @@
-import { Party, ContractId, Contract } from '@digitalasset/daml-json-types';
+import { Party, ContractId } from '@digitalasset/daml-json-types';
+import { CreateEvent } from '@digitalasset/daml-ledger-fetch';
 import * as v3 from '../daml/edb5e54da44bc80782890de3fc58edb5cc227a6b7e8c467536f8674b0bf4deb7/DAVL';
 import { contramap, Ord, ordString, getDualOrd } from 'fp-ts/lib/Ord';
 import { partition } from 'fp-ts/lib/Array';
@@ -34,7 +35,7 @@ export const emptyVacations: Vacations = {
   past: [],
 }
 
-export const prettyRequests = (requestContracts: Contract<v3.VacationRequest>[]): Vacation[] => {
+export const prettyRequests = (requestContracts: CreateEvent<v3.VacationRequest>[]): Vacation[] => {
   const requests: Vacation[] =
     requestContracts.map(({contractId, argument}) => makeVacation(contractId, argument.vacation));
   requests.sort(ordVacationOnFromDate.compare);
@@ -42,7 +43,7 @@ export const prettyRequests = (requestContracts: Contract<v3.VacationRequest>[])
 }
 
 
-export const splitVacations = (vacationContracts: Contract<v3.Vacation>[]) => {
+export const splitVacations = (vacationContracts: CreateEvent<v3.Vacation>[]) => {
   const today = moment().format('YYYY-MM-DD');
   const vacations = vacationContracts.map((vacation) => makeVacation(vacation.contractId, vacation.argument))
   const {left: upcoming, right: past} =


### PR DESCRIPTION
What was called `Contract` until now is actually a create event. Hence the
renaming. We'll most likely get a `Contract` type in DAML as well and this
renaming will avoid a name conflict. Also, create events are not part of
DAML-LF values and hence not generated by `daml2ts`. Thus, there's not need
to have them in `daml-json-types`. Instead, they should be in a future
`daml-json-api-types` package which captures the types used by the JSON API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/100)
<!-- Reviewable:end -->
