### PR TITLE
fix race condition in ui deployment

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -163,7 +163,7 @@ STARTUP
 }
 
 resource "google_compute_instance" "proxy" {
-  name         = "proxy"
+  name         = "proxy-${var.ui}"
   machine_type = "n1-standard-2"
 
   boot_disk {


### PR DESCRIPTION
With the current configuration, there is a race condition between Terraform and GCP that goes something like this, when we want to deploy a new version of the frontend. The issue is that the instance_group, which is used for routing, includes the proxy instance by name.

1. Terraform looks at its configuration files, and sees the new version of the frontend. It computes the new end state based on that.
2. In that new end state, there needs to be a new proxy instance. However, its name is going to be the same, so Terraform computes no change required for the instance_group. Therefore, the plan Terraform computes is limited to destroying and recreating the proxy instance.
3. Terraform asks GCP to destroy the old instance. To keep the entire state of the world consistent, **GCP removes the now-deleted instance from the instance_group**.
4. Terraform creates a new instance with the same name, expecting it to be picked up by the instance_group.

By picking a new name for the instance, the new sequence should be:

1. Terraform computes a plan that includes changing the instance_group.
2. Terraform asks GCP to delete the old instance. GCP also removes it from the instance_group.
3. Terraform creates the new instance.
4. Terraform adds the new instance to the group.

You'll note that the website will give a 503 in-between steps 2 and 4; we can look at how to fix that if it's an issue, but I don't think we're at a point where zero-downtime deployments are a useful goal.