### PR TITLE
bind sandbox and jso-api to 0.0.0.0

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -140,7 +140,7 @@ docker exec sandbox /bin/sh -c "while ! nc -z localhost:6865; do sleep 1; done"
 # running against an existing database, so we need to manually deploy the DAR
 # file after it has started. Since uploading a DAR file is idempotent, this
 # should not break if/when the sandbox behaviour changes.
-docker exec sandbox /bin/sh -c "for f in /app/released/*; do /root/.daml/bin/daml ledger upload-dar --host=127.0.0.1 --port=6865 \$f; done"
+docker exec sandbox /bin/sh -c "for f in /app/released/*.dar; do /root/.daml/bin/daml ledger upload-dar --host=127.0.0.1 --port=6865 \$f; done"
 # </workaround>
 
 docker run --name json-api -d --link sandbox -p 7575:7575 gcr.io/da-dev-pinacolada/json-api:${var.json} --ledger-host sandbox --ledger-port 6865 --http-port 7575

--- a/infra/json-api.docker
+++ b/infra/json-api.docker
@@ -4,4 +4,4 @@ RUN mkdir /app
 COPY daml-sdk /app/daml-sdk
 
 WORKDIR /app
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/json-api-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "json-api", "--application-id", "DAVL-JSON"]
+ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/json-api-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "json-api", "--application-id", "DAVL-JSON", "--address", "0.0.0.0"]

--- a/infra/sandbox.docker
+++ b/infra/sandbox.docker
@@ -15,4 +15,4 @@ RUN curl https://get.daml.com | sh -s 0.13.32
 
 WORKDIR /app
 
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/sandbox-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "sandbox", "--wall-clock-time", "--ledgerid", "DAVL"]
+ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/sandbox-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "sandbox", "--wall-clock-time", "--ledgerid", "DAVL", "--address", "0.0.0.0"]


### PR DESCRIPTION
0.13.42 changed the default from 0.0.0.0 to localhost for sandbox. json-api is still defaulting to 0.0.0.0 for now, but by making it explicit we make our deployment future-proof in case it follows in the steps of the sandbox.

This also changes the deployment process to only try to upload *.dar files to the sandbox, to avoid trying to upload the README.md file that has been added to the deployed folder.