### PR TITLE
Fix type of template id in tests

### DIFF
--- a/ui/src/daml-react-hooks/ledgerStore.test.tsx
+++ b/ui/src/daml-react-hooks/ledgerStore.test.tsx
@@ -4,10 +4,7 @@ import * as jtv from '@mojotech/json-type-validation'
 import * as LedgerStore from './ledgerStore'
 
 // mock data
-const templateId = {  packageId: 'A'
-                    , moduleName: 'B'
-                    , entityName : 'C'
-                    }
+const templateId = 'template-id';
 const template = {  templateId: templateId
                   , Archive: {  template: () => template
                               , choiceName: 'Archive'


### PR DESCRIPTION
I don't know why this doesn't get type checked. However, since we're moving
this library to the `daml` repo soon and there test do get typechecked,
I'm not too fussed about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/137)
<!-- Reviewable:end -->
