### PR TITLE
v3-v4-upgrade command use ledger params not config file

### DIFF
--- a/admin-cli/package.json
+++ b/admin-cli/package.json
@@ -16,15 +16,15 @@
     "@daml/ledger": "0.13.51",
     "@types/jwt-simple": "^0.5.33",
     "jwt-simple": "^0.5.6",
-    "node": "^13.6.0",
-    "@types/yargs": "^15.0.3"
+    "node": "^13.6.0"
   },
   "devDependencies": {
     "@types/node": "^13.1.8",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
     "eslint": "^6.8.0",
-    "typescript": "~3.7.5"
+    "typescript": "~3.7.5",
+    "@types/yargs": "^15.0.3"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This PR fixes the `v3-v4-upgrade` command to use command line provided ledger parameters rather than a config file. It incidentally finishes off  issues left over in https://github.com/digital-asset/davl/pull/151:
  - https://github.com/digital-asset/davl/pull/151#discussion_r374982461;
 - https://github.com/digital-asset/davl/pull/151#discussion_r374984854.