### PR TITLE
Add autocomplete property to inputs on login screen

### DIFF
--- a/ui/src/components/LoginScreen.tsx
+++ b/ui/src/components/LoginScreen.tsx
@@ -130,6 +130,7 @@ const LoginScreen: React.FC<Props> = (props) => {
               icon='user'
               iconPosition='left'
               placeholder='Username'
+              autoComplete='username'
               value={username}
               onChange={e => setUsername(e.currentTarget.value)}
             />
@@ -139,6 +140,7 @@ const LoginScreen: React.FC<Props> = (props) => {
               iconPosition='left'
               placeholder='Password'
               type='password'
+              autoComplete='current-password'
               value={password}
               onChange={e => setPassword(e.currentTarget.value)}
             />


### PR DESCRIPTION
This fixes a warning I get in Chrome. Doing so seems to be good practice:
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls%3A-the-autocomplete-attribute

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/159)
<!-- Reviewable:end -->
