### PR TITLE
Add a proxy for the websocket endpoints

### DIFF
--- a/infra/nginx.conf.sh
+++ b/infra/nginx.conf.sh
@@ -44,6 +44,14 @@ http {
   server {
     listen 80;
     server_name davl.da-ext.net;
+
+    location /contracts/searchForever {
+      proxy_pass http://${LEDGER_IP_PORT};
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+    }
+
     location /contracts {
       proxy_pass http://${LEDGER_IP_PORT};
     }

--- a/ui/src/daml-react-hooks/streamLedger.ts
+++ b/ui/src/daml-react-hooks/streamLedger.ts
@@ -45,7 +45,8 @@ export default class StreamLedger extends Ledger {
   constructor(token: string, baseUrl?: string) {
     super(token, baseUrl);
     if (!baseUrl) {
-      this.wsBaseUrl = `ws://${window.location.hostname}:7575/`;
+      const protocol = window.location.protocol === 'http:' ? 'ws:' : 'wss:';
+      this.wsBaseUrl = `${protocol}//${window.location.host}/`;
     } else if (!baseUrl.startsWith('http')) {
       throw Error(`The ledger base URL must start with 'http'. (${baseUrl})`);
     } else if (!baseUrl.endsWith('/')) {


### PR DESCRIPTION
We also need to make sure to use `wss://...` when we use `https://...`.

Currently, using `yarn start` is broken since I haven't figure out how to make the webpack dev server proxy websockets. I'm working on it right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/174)
<!-- Reviewable:end -->
