### PR TITLE
Revert "Increase heart beat frequence of JSON API"

### DIFF
--- a/infra/json-api.docker
+++ b/infra/json-api.docker
@@ -4,4 +4,4 @@ RUN mkdir /app
 COPY daml-sdk /app/daml-sdk
 
 WORKDIR /app
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/json-api-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "json-api", "--application-id", "DAVL-JSON", "--address", "0.0.0.0", "--websocket-config", "heartBeatPer=2"]
+ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/json-api-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "json-api", "--application-id", "DAVL-JSON", "--address", "0.0.0.0"]


### PR DESCRIPTION
Reverts digital-asset/davl#179

Apparently, the low heartbeat frequency seems to be fine. GCP simply kills connections after 30 secs regardless of whether they are busy or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/181)
<!-- Reviewable:end -->
