### PR TITLE
Backport computation of ACS in Ledger.streamQuery

### DIFF
--- a/ui/src/utils/employee.ts
+++ b/ui/src/utils/employee.ts
@@ -12,7 +12,7 @@ export type EmployeeSummary = {
 export const ordEmployeeSummaryOnName: Ord<EmployeeSummary> =
   contramap((summary: EmployeeSummary) => summary.employee)(ordString);
 
-export const prettyEmployeeSummaries = (allocations: CreateEvent<v4.EmployeeVacationAllocation>[]): EmployeeSummary[] => {
+export const prettyEmployeeSummaries = (allocations: readonly CreateEvent<v4.EmployeeVacationAllocation>[]): EmployeeSummary[] => {
   const staff = allocations.map(({payload: {employeeRole: {employee, boss}, remainingDays}}) =>
     ({employee, boss, remainingVacationDays: remainingDays}));
   staff.sort(ordEmployeeSummaryOnName.compare);

--- a/ui/src/utils/vacation.ts
+++ b/ui/src/utils/vacation.ts
@@ -35,7 +35,7 @@ export const emptyVacations: Vacations = {
   past: [],
 }
 
-export const prettyRequests = (requestContracts: CreateEvent<v4.VacationRequest>[]): Vacation[] => {
+export const prettyRequests = (requestContracts: readonly CreateEvent<v4.VacationRequest>[]): Vacation[] => {
   const requests: Vacation[] =
     requestContracts.map(({contractId, payload}) => makeVacation(contractId, payload.vacation));
   requests.sort(ordVacationOnFromDate.compare);
@@ -43,7 +43,7 @@ export const prettyRequests = (requestContracts: CreateEvent<v4.VacationRequest>
 }
 
 
-export const splitVacations = (vacationContracts: CreateEvent<v4.Vacation>[]) => {
+export const splitVacations = (vacationContracts: readonly CreateEvent<v4.Vacation>[]) => {
   const today = moment().format('YYYY-MM-DD');
   const vacations = vacationContracts.map((vacation) => makeVacation(vacation.contractId, vacation.payload))
   const {left: upcoming, right: past} =


### PR DESCRIPTION
Backport of https://github.com/digital-asset/daml/pull/4563. The changes to `streamQuery.ts` are straightforward backport of the changes there to a slightly older version of the JSON API.

The `useStreamQuery` hook in `hooks.ts` gets significantly simpler since it can take the ACS from the stream rather than maintain it itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/194)
<!-- Reviewable:end -->
