### PR TITLE
fix trigger deployment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
               DOCKER_DIR=$(mktemp -d)
               cp -r released $DOCKER_DIR/released
               cp -r $HOME/.daml/sdk/$SDK_VERSION/daml-sdk $DOCKER_DIR/daml-sdk
-              docker build -t $SANDBOX_IMAGE -f docker/sandbox.docker $DOCKER_DIR
+              docker build -t $SANDBOX_IMAGE -f docker/sandbox.docker --build-arg sdk_version=$(cat SDK_VERSION) $DOCKER_DIR
               docker push $SANDBOX_IMAGE
               echo "Done building $SANDBOX_IMAGE."
               tell_slack sandbox:$SANDBOX_TAG
@@ -148,7 +148,6 @@ jobs:
               echo "Building trigger image version $TRIGGER_TAG..."
               TRIGGER_IMAGE=gcr.io/da-dev-pinacolada/trigger:$TRIGGER_TAG
               DOCKER_DIR=$(mktemp -d)
-              echo '{"company": "Digital Asset"}' > $DOCKER_DIR/init.json
               (cd upgrade-v4-v5-automation && daml build -o $DOCKER_DIR/automation.dar)
               cp -r $HOME/.daml/sdk/$SDK_VERSION/daml-sdk $DOCKER_DIR/daml-sdk
               docker build -t $TRIGGER_IMAGE -f docker/trigger.docker $DOCKER_DIR
@@ -177,7 +176,7 @@ jobs:
           # provides; fortunately terraform is a single, self-contained
           # executable.
           TF_DIR=$(mktemp -d)
-          wget https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_linux_amd64.zip -O $TF_DIR/tf.zip
+          wget https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_linux_amd64.zip -O $TF_DIR/tf.zip
           ( cd $TF_DIR; unzip tf.zip )
           terraform=$TF_DIR/terraform
 

--- a/docker/sandbox.docker
+++ b/docker/sandbox.docker
@@ -1,5 +1,7 @@
 FROM openjdk:8-alpine
 
+ARG sdk_version
+
 RUN mkdir /app
 COPY daml-sdk /app/daml-sdk
 COPY released /app/released
@@ -10,7 +12,7 @@ COPY released /app/released
 # file after it has started. Since uploading a DAR file is idempotent, this
 # should not break if/when the sandbox behaviour changes.
 RUN apk add curl bash
-RUN curl https://get.daml.com | sh -s 0.13.32
+RUN curl https://get.daml.com | sh -s ${sdk_version}
 # </workaround>
 
 WORKDIR /app

--- a/docker/trigger.docker
+++ b/docker/trigger.docker
@@ -3,8 +3,7 @@ FROM openjdk:8-alpine
 RUN mkdir /app
 COPY daml-sdk /app/daml-sdk
 COPY automation.dar /app/automation.dar
-COPY init.json /app/init.json
 
 WORKDIR /app
 
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/trigger-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "trigger", "--dar", "/app/automation.dar", "--trigger-name", "Automation:finish", "--ledger-party", "Digital Asset", "--static-time", "--init-file", "/app/init.json"]
+ENTRYPOINT ["java", "-Dlogback.configurationFile=/app/daml-sdk/trigger-logback.xml", "-jar", "/app/daml-sdk/daml-sdk.jar", "trigger", "--dar", "/app/automation.dar", "--trigger-name", "Automation:finish", "--ledger-party", "Digital Asset", "--static-time"]


### PR DESCRIPTION
This PR makes three changes:

1. It fixes the trigger CLI args. I got confused between the new trigger we're adding and the new script we're going to add soon.
2. It changes the Terraform version we use to match what I have installed locally, because now that I've touched the state file it needs to be the same version.
3. It changes the ledger Docker container to get the SDK version (for the upload-dar workaround, and possibly soon for the script) from the SDK_VERSION file.