### PR TITLE
Store the credentials in the session storage

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -13,7 +13,25 @@ const wsBaseUrl =
  * React component for the entry point into the application.
  */
 const App: React.FC = () => {
-  const [credentials, setCredentials] = useState<Credentials | undefined>();
+  const party0 = sessionStorage.getItem("party");
+  const token0 = sessionStorage.getItem("token");
+  const credentials0 =
+    party0 !== null && token0 !== null
+      ? { party: party0, token: token0 }
+      : undefined;
+  const [credentials, setCredentials] = useState(credentials0);
+
+  const handleLogin = (credentials: Credentials) => {
+    sessionStorage.setItem("party", credentials.party);
+    sessionStorage.setItem("token", credentials.token);
+    setCredentials(credentials);
+  };
+
+  const handleLogout = () => {
+    sessionStorage.removeItem("party");
+    sessionStorage.removeItem("token");
+    setCredentials(undefined);
+  };
 
   return credentials ? (
     <DamlLedger
@@ -21,10 +39,10 @@ const App: React.FC = () => {
       wsBaseUrl={wsBaseUrl}
       party={credentials.party}
     >
-      <MainScreen onLogout={() => setCredentials(undefined)} />
+      <MainScreen onLogout={handleLogout} />
     </DamlLedger>
   ) : (
-    <LoginScreen onLogin={setCredentials} />
+    <LoginScreen onLogin={handleLogin} />
   );
 };
 


### PR DESCRIPTION
This allows for reloading the UI in the browser without being thrown
back to the login screen. Impulsive Cmd+R pressers will love this.

I'm also considering to put this into `create-daml-app` and DAVL is my
testbed once more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/223)
<!-- Reviewable:end -->
