### PR TITLE
Remove the reload button from the main view

### DIFF
--- a/ui/src/components/MainScreen.tsx
+++ b/ui/src/components/MainScreen.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Image, Menu, Container, Grid } from "semantic-ui-react";
 import EmployeeView from "../features/employeeView/EmployeeView";
 import BossView from "../features/bossView/BossView";
-import { useParty, useReload } from "@daml/react";
+import { useParty } from "@daml/react";
 
 type Props = {
   onLogout: () => void;
@@ -13,7 +13,6 @@ type Props = {
  */
 const MainScreen: React.FC<Props> = props => {
   const party = useParty();
-  const reload = useReload();
 
   return (
     <>
@@ -30,12 +29,6 @@ const MainScreen: React.FC<Props> = props => {
         </Menu.Item>
         <Menu.Menu position="right">
           <Menu.Item position="right">You are logged in as {party}.</Menu.Item>
-          <Menu.Item
-            position="right"
-            active={false}
-            onClick={() => reload()}
-            icon="refresh"
-          />
           <Menu.Item
             position="right"
             active={false}


### PR DESCRIPTION
Since we're using the streaming hooks everywhere now, there's no more
point in having this button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/224)
<!-- Reviewable:end -->
