### PR TITLE
Fix a bug where only employees on v4 will be shown

### DIFF
--- a/ui/src/features/bossView/Staff.tsx
+++ b/ui/src/features/bossView/Staff.tsx
@@ -19,7 +19,7 @@ const Staff: React.FC = () => {
     [party],
   );
   const loading = allocationsV4.loading || allocationsV5.loading;
-  const contracts = allocationsV4.contracts || allocationsV5.contracts;
+  const contracts = allocationsV4.contracts.concat(allocationsV5.contracts);
   const staff = prettyEmployeeSummaries(contracts);
 
   return (


### PR DESCRIPTION
Instead of concatenating the list of vacation allocations from version
4 and 5 we `||` then, which makes zero sense. I'm quite sad this hasn't
been caught by the type checker but apparently this is a common idiom
in JavaScript. Anyway, here's the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/225)
<!-- Reviewable:end -->
