### PR TITLE
Use the useLedger hook in the UI

### DIFF
--- a/ui/src/features/bossView/BossView.tsx
+++ b/ui/src/features/bossView/BossView.tsx
@@ -3,7 +3,7 @@ import VacationListSegment from "../../components/VacationListSegment";
 import { Vacation, prettyRequests, splitVacations } from "../../utils/vacation";
 import { Segment } from "semantic-ui-react";
 import Staff from "./Staff";
-import { useStreamQuery, useExercise, useParty } from "@daml/react";
+import { useStreamQuery, useParty, useLedger } from "@daml/react";
 import v4 from "@daml.js/davl-0.0.4";
 import v5 from "@daml.js/davl-0.0.5";
 import { ContractId } from "@daml/types";
@@ -11,6 +11,7 @@ import { toast } from "react-semantic-toasts";
 
 const BossView: React.FC = () => {
   const party = useParty();
+  const ledger = useLedger();
 
   const vacationsV4 = useStreamQuery(
     v4.DAVL.Vacation,
@@ -44,23 +45,18 @@ const BossView: React.FC = () => {
   ]);
   const loadingRequests = requestsV4.loading || requestsV5.loading;
 
-  const exerciseApproveRequestV4 = useExercise(
-    v4.DAVL.VacationRequest.VacationRequest_Accept,
-  );
-  const exerciseApproveRequestV5 = useExercise(
-    v5.DAVL.V5.VacationRequest.VacationRequest_Accept,
-  );
-
   const handleApproveRequest = async (vacation: Vacation) => {
     switch (vacation.version) {
       case "v4":
-        await exerciseApproveRequestV4(
+        await ledger.exercise(
+          v4.DAVL.VacationRequest.VacationRequest_Accept,
           vacation.contractId as ContractId<v4.DAVL.VacationRequest>,
           {},
         );
         break;
       case "v5":
-        await exerciseApproveRequestV5(
+        await ledger.exercise(
+          v5.DAVL.V5.VacationRequest.VacationRequest_Accept,
           vacation.contractId as ContractId<v5.DAVL.V5.VacationRequest>,
           {},
         );


### PR DESCRIPTION
The `useExercise` and `useExerciseByKey` hooks have been deprecated in
favor of using the `useLedger` hook in combination with
`Ledger.exercsise` and `Ledger.exerciseByKey`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/davl/232)
<!-- Reviewable:end -->
