### PR TITLE
db backups

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -179,7 +179,7 @@ echo "\$(date -Is -u) start backup"
 
 TMP=\$(mktemp)
 BACKUP=\$(date -u +%Y%d%m%H%M%SZ).gz
-docker exec -ti pg pg_dump -U davl -d davl-db | gzip -9 > \$TMP
+docker exec pg pg_dump -U davl -d davl-db | gzip -9 > \$TMP
 gsutil cp \$TMP ${google_storage_bucket.db-backups.url}/\$BACKUP
 rm \$TMP
 

--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -95,7 +95,7 @@ STARTUP
 resource "google_storage_bucket" "db-backups" {
   name = "davl-db-backups"
 
-  storage_class = "REGIONAL"
+  storage_class = "STANDARD"
 
   # keep 60 days of backups
   lifecycle_rule {
@@ -109,6 +109,7 @@ resource "google_storage_bucket" "db-backups" {
 }
 
 resource "google_compute_instance" "backed-up-db" {
+  count        = 0
   name         = "db"
   machine_type = "n1-standard-2"
 

--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -197,7 +197,9 @@ tail -f /root/log
 STARTUP
 }
 
+/*
 resource "google_compute_instance" "ledger" {
+  count        = 0
   name         = "ledger"
   machine_type = "n1-standard-2"
 
@@ -284,6 +286,7 @@ STARTUP
 }
 
 resource "google_compute_instance" "proxy" {
+  count        = 0
   name         = "proxy-${var.ui}"
   machine_type = "n1-standard-2"
 
@@ -328,6 +331,7 @@ docker run -p 8081:8081 -p 8080:8080 -e NAVIGATOR_IP_PORT=${google_compute_insta
 
 STARTUP
 }
+*/
 
 resource "google_compute_address" "proxy" {
   name         = "proxy"
@@ -339,7 +343,7 @@ resource "google_compute_address" "proxy" {
 // machine.
 resource "google_compute_instance_group" "frontend" {
   name      = "frontend"
-  instances = ["${google_compute_instance.proxy.self_link}"]
+  instances = [/*"${google_compute_instance.proxy.self_link}"*/]
   named_port {
     name = "http"
     port = "8081"

--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -180,7 +180,7 @@ echo "\$(date -Is -u) start backup"
 TMP=\$(mktemp)
 BACKUP=\$(date -u +%Y%d%m%H%M%SZ).gz
 docker exec pg pg_dump -U davl -d davl-db | gzip -9 > \$TMP
-gsutil cp \$TMP ${google_storage_bucket.db-backups.url}/\$BACKUP
+$(which gsutil) cp \$TMP ${google_storage_bucket.db-backups.url}/\$BACKUP
 rm \$TMP
 
 echo "\$(date -Is -u) end backup"


### PR DESCRIPTION
This PR aims at adding backups to the DAVL project. We've been running without a safety net for long enough now.

Because we already have a database in production, and because Terraform tends to replace machines by deleting the existing ones, a bit of care will be needed in deployment. The plan is to:

0. Create a bucket to store backups.
1. Manually create a backup from the existing DB, upload to bucket.
2. Create a new machine, backed-up-db, that behaves as the current DB but:
   1. Downloads and restores the latest snapshot on startup.
   2. Creates and uploads a new snapshot every hour.
3. Wait a bit to check everything seems fine with the new machine; in particular, check that:
   1. It does indeed upload a new snapshot every hour.
   2. It does indeed restore from the latest server. This might involve manually killing the machine.
4. Shut down the DAVL website (ui and ledger machines).
5. Manually create a backup from the existing DB, upload to bucket.
6. Delete existing machine, reset backed-up-db (which at this point will load from the manual backup).
7. Restart ledger and ui machines, but having the ledger machine connect to the backed-up-db machine.

At the time of opening, the PR contains a single, untested draft of steps 0 and 2.