### PR TITLE
explicit tf defaults

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -430,7 +430,10 @@ resource "google_compute_backend_service" "frontend" {
   backend {
     group = "${google_compute_instance_group.frontend.self_link}"
   }
-  log_config { enable = true }
+  log_config {
+    enable      = true
+    sample_rate = 1
+  }
 }
 
 // UI: serve application; redirect connections to port 443 of the external IP
@@ -463,7 +466,10 @@ resource "google_compute_backend_service" "ui" {
   backend {
     group = "${google_compute_instance_group.frontend.self_link}"
   }
-  log_config { enable = true }
+  log_config {
+    enable      = true
+    sample_rate = 1
+  }
   # Because GCP is... well, GCP, this timeout is not just for failed
   # connections, i.e. the maximum time the proxy would wait befire returning an
   # error to clients when the backend doesn't respond, it's also the maximum
@@ -501,7 +507,10 @@ resource "google_compute_backend_service" "navigator" {
   backend {
     group = "${google_compute_instance_group.frontend.self_link}"
   }
-  log_config { enable = true }
+  log_config {
+    enable      = true
+    sample_rate = 1
+  }
 }
 
 output "proxy-ip" {


### PR DESCRIPTION
sample_rate = 1 is the default value, but for some reason if it's not set, even though it is described as optional, Terraform eternally believes that the current state differs from the one in the files and, when applying, tries to set the value from 1 to null, which GCP interprets as resetting to the default value (of 1).