### PR TITLE
add dev-env

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+echo "[dev-env] Setting up DA Development Environment"
+eval "$(dev-env/bin/dade-assist)"
+
+# Load private overrides
+[[ -f .envrc.private ]] && source_env .envrc.private

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,10 @@ jobs:
       - bash: |
           set -euo pipefail
 
+          sudo mkdir /nix && sudo chown $USER /nix
+          curl -L https://nixos.org/nix/install | sh
+          eval "$(dev-env/bin/dade-assist)"
+
           tell_slack () {
               local MESSAGE=$(git log --pretty=format:%s -n1)
               curl -XPOST \
@@ -93,15 +97,6 @@ jobs:
                    --data "{\"text\":\"<https://dev.azure.com/digitalasset/davl/_build/results?buildId=$(Build.BuildId)|$MESSAGE>:\n$1\n\"}" \
                    $(Slack.URL)
           }
-
-          # Install Terraform, so we pin the version regardless of what Azure
-          # provides; fortunately terraform is a single, self-contained
-          # executable.
-          TF_DIR=$(mktemp -d)
-          TF_VER="0.12.26"
-          wget https://releases.hashicorp.com/terraform/${TF_VER}/terraform_${TF_VER}_linux_amd64.zip -O $TF_DIR/tf.zip
-          ( cd $TF_DIR; unzip tf.zip )
-          terraform=$TF_DIR/terraform
 
           # Deploying new code should be a routine change that CI can
           # automate, but changing the shape of the infrastructure should
@@ -116,7 +111,7 @@ jobs:
               git checkout $previous_sha
               set +e
               # returns 0 if no changes to apply, 1 on error and 2 if changes
-              $terraform plan -detailed-exitcode -var-file=deployed-versions.tfvars
+              terraform plan -detailed-exitcode -var-file=deployed-versions.tfvars
               local result=$?
               set -e
               git checkout $current_sha
@@ -145,7 +140,7 @@ jobs:
           gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
           cd infra
-          $terraform init
+          terraform init
 
           echo "Sanity check for Terraform config."
           # `terraform plan` checks the difference between the tf files and
@@ -155,7 +150,7 @@ jobs:
           # 1. The Terraform files are (still) well-formed, and
           # 2. The CI runner still has all the permissions it needs to at least
           #    check if anything needs to be redeployed.
-          $terraform plan -var-file=deployed-versions.tfvars
+          terraform plan -var-file=deployed-versions.tfvars
           # "False" is the string returned by Azure expressions for the boolean
           # value false.
           if [ "$IS_MASTER" = "False" ]; then
@@ -168,7 +163,7 @@ jobs:
                   tell_slack "<!here> *WARNING*: Latest commit changes infra. Please apply manually."
               else
                   if current_commit_changes_versions; then
-                      if $terraform apply -auto-approve -var-file=deployed-versions.tfvars; then
+                      if terraform apply -auto-approve -var-file=deployed-versions.tfvars; then
                           tell_slack "started deployment of:\n\`\`\`$(cat deployed-versions.tfvars | jq -Rs . | sed 's/^"//' | sed 's/"$//')\`\`\`"
                           sleep 10
                           # There is a race condition whereby the ui server
@@ -177,7 +172,7 @@ jobs:
                           # gets Terraform to notice and correc tthe
                           # inconsistency. This is not the most elegant way to
                           # solve it, but should work for now.
-                          $terraform apply -auto-approve -var-file=deployed-versions.tfvars
+                          terraform apply -auto-approve -var-file=deployed-versions.tfvars
                       else
                           tell_slack "<!here> *ERROR*: failed to deploy"
                       fi

--- a/dev-env/.gitignore
+++ b/dev-env/.gitignore
@@ -1,0 +1,2 @@
+lib/gc-roots/
+var/gc-roots/

--- a/dev-env/bin/dade-assist
+++ b/dev-env/bin/dade-assist
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
+exec "${DADE_DEVENV_DIR}/lib/dade-dump-profile"

--- a/dev-env/bin/terraform
+++ b/dev-env/bin/terraform
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -1,0 +1,16 @@
+build-max-jobs = 2
+binary-caches = https://cache.nixos.org
+binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+
+# Keep build-time dependencies of non-garbage outputs around
+gc-keep-outputs = true
+gc-keep-derivations = true
+
+# NOTE(JM): This is broken on Mac: "cannot link ... : Operation not permitted"
+# auto-optimise-store = true
+
+# NOTE(D3): This is needed in order to run nix commands on monorepo from a Docker container.
+build-users-group =
+
+# Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
+http2 = false

--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -1,0 +1,134 @@
+# -*- shell-script -*-
+# Common development environment definitions
+#
+
+# Check if DADE_DEBUG is set. In cases when outside shell has set -u,
+# and DADE_DEBUG is not set, then -z "${DADE_DEBUG}" would fail.
+# This form ensures that it is not the case
+if [[ -n "${DADE_DEBUG+x}" ]]; then
+    set -x
+fi
+
+DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_BASE_ROOT="$( cd "${DADE_CURRENT_SCRIPT_DIR}/../../" && pwd)"
+
+errcho() {
+  >&2 echo "[dev-env] $@"
+}
+
+readAbsolutePath() {
+  perl -MCwd -e 'print Cwd::abs_path shift' $1
+}
+
+# Detect if we are being used within another working tree and bail out.
+OLD_PWD="$PWD"
+while [ "$PWD" != "/" ]; do
+  if [ -h "$PWD" ]; then # follow symlink if PWD is one
+    cd $(readAbsolutePath "$PWD")
+  fi
+  if [[ -e dev-env/lib/dade-common && "$PWD" != "$DADE_BASE_ROOT" ]]; then
+    errcho "Fatal: Using dev-env from $DADE_BASE_ROOT, but running under $PWD."
+    errcho "Please source the right dev-env profile:"
+    errcho "  bash: 'source $PWD/dev-env/profile_bash.sh'"
+    errcho "  zsh:  'source $PWD/dev-env/profile_zsh.sh'"
+
+    exit 1
+  fi
+  cd ..
+done
+cd "$OLD_PWD"
+
+export DADE_REPO_ROOT="${DADE_REPO_ROOT:-$DADE_BASE_ROOT}"
+export DADE_DEVENV_DIR="${DADE_BASE_ROOT}/dev-env"
+export DADE_LIB_DIR="${DADE_DEVENV_DIR}/lib"
+# If specified, use the outer layer, e.g. dev-env bootstrap script in another
+# repository, special var director.
+export DADE_VAR_DIR="${DADE_VAR_DIR:-$DADE_DEVENV_DIR/var}"
+# DADE_GC_ROOTS_ROOT is used by the CI builds on shared nfs
+DADE_GC_ROOTS="${DADE_GC_ROOTS_ROOT:-}${DADE_VAR_DIR}/gc-roots"
+
+# Make sure that Nix is available
+source "${DADE_CURRENT_SCRIPT_DIR}/ensure-nix"
+
+# Compute expected dade base hash
+dadeBaseHash() {
+    nix-hash "$DADE_DEVENV_DIR/../nix"
+}
+
+# List tools defined in dade
+dadeListTools() {
+    cat $(nix-build $DADE_BASE_ROOT/nix -A dade.tools-list)
+}
+
+# dadeGetOutput get output of a target
+#
+#   target: Attribute in the $DADE_BASE_ROOT/nix/default.nix tools attrset to
+#     realize.
+#   outputName: the output name of the Nix derivation, where the derivation is
+#     relalized into. This is necessary, since Nix's --add-root produces a
+#     unpredictable symlink name.
+dadeGetOutput() {
+    local target=$1
+    local outputName=$2
+    local output="$target"
+    if [[ "$outputName" != "out" ]]; then
+        output="${output}-${outputName}"
+    fi
+    echo $output
+}
+
+# buildTool <attribute> <outputName> <force>
+#
+#   attribute: Attribute in the $DADE_BASE_ROOT/nix/default.nix tools attrset to
+#     realize.
+#   outputName: the output name of the Nix derivation, where the derivation is
+#     relalized into. This is necessary, since Nix's --add-root produces a
+#     unpredictable symlink name.
+#   force: if set to 1, forces re-initialization of the tool.
+buildTool() {
+  local attr=$1
+  local outputName=$2
+  local force=$3
+  shift 3
+  local target="$DADE_GC_ROOTS/$attr"
+  local hashfile="${target}.hash"
+  local hash="nope"
+  local currentHash="$(dadeBaseHash)"
+  local forced=""
+  test -e "$hashfile" && hash="$(cat "$hashfile")"
+
+  # Build the tool if no the garbage collector root exists or if the
+  # hash of the definitions is different.
+  # We depend on the behavior of nix-build to name a gc root as target-foo, for
+  # a non-out output.
+  DADE_BUILD_RESULT="$(dadeGetOutput $target $outputName)"
+  if [[ ! -e "$DADE_BUILD_RESULT" || "$force" -eq 1 || "$hash" != "$currentHash" ]]; then
+    set -e
+    test "$force" -eq 1 && forced=" (forced)"
+    errcho "Building tools.${attr}${forced}..."
+    # Allow to fail, so we can capture outpath and to capture the exit code too.
+    set +e
+    outpath=$(nix-build "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
+    local dade_build_exit_code=$?
+    set -e
+    if [[ "$dade_build_exit_code" != "0" ]]; then
+      errcho "Build of tools.$attr has failed!"
+      exit 1
+    fi
+    errcho "Built tools.$attr in $outpath and linked to $DADE_BUILD_RESULT"
+    printf "$currentHash" >| "$hashfile"
+    set +e
+  fi
+}
+
+# execTool <attribute> <outputName> <binary>
+execTool() {
+  local attr=$1
+  local outputName=$2
+  local binary=$3
+  shift 3
+  [[ $PATH =~ (^|.*:)$DADE_DEVENV_DIR/bin($|:.*) ]] || \
+    eval "$(${DADE_DEVENV_DIR}/bin/dade assist)"
+  buildTool $attr $outputName 0
+  exec "$(readlink "$DADE_BUILD_RESULT")/bin/$binary" "$@"
+}

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# Prints out commands to set up profile for both bash and zsh.
+#
+# Requires:
+# - DADE_DEVENV_DIR correctly set, DADE_BASE is accepted for compatibility
+# Optional:
+# - DADE_VAR_DIR to use separate directory for mutable persisted state.
+
+# Reset locale to ensure no warnings from the nix-build calls below.
+# The nix-build Perl script will use a Nix glibc, which comes without
+# any locales. We can therefore not make any assumptions about the
+# available locales at this point (DEL-2851).
+unset LC_ALL
+unset LANG
+
+unset NIX_CONF_DIR
+unset NIX_PATH
+
+set -Eeuo pipefail
+
+if [[ -n "${DADE_DEBUG+x}" ]]; then
+    set -x
+fi
+
+errcho() {
+    >&2 echo "[dev-env] $*"
+}
+
+check_nix_version() {
+    # Keep in sync with dade-nix-install.
+    NIX_MAJOR="$1"
+    NIX_MINOR="$2"
+    NIX_PATCH="$3"
+    local current
+    current=$(nix-env --version)
+    if [[ $current =~ ([0-9])[.]([0-9]+)([.]([0-9]+))? ]]; then
+        local current_major="${BASH_REMATCH[1]}"
+        local current_minor="${BASH_REMATCH[2]}"
+        local current_patch="${BASH_REMATCH[4]:-0}"
+        if [[ $current_major -lt $NIX_MAJOR ]] ||
+           [[ $current_major -eq $NIX_MAJOR && $current_minor -lt $NIX_MINOR ]] ||
+           [[ $current_major -eq $NIX_MAJOR && $current_minor -eq $NIX_MINOR && $current_patch -lt $NIX_PATCH ]];
+        then
+            errcho "WARNING: Version ${current_major}.${current_minor}.${current_patch} detected, but ${NIX_MAJOR}.${NIX_MINOR}.${NIX_PATCH} or higher required."
+            errcho "Please run 'nix upgrade-nix' or 'curl -sSfL https://nixos.org/nix/install | sh' to update Nix."
+        fi
+    else
+      errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly. Contact #disc-enterprise-pipe immediately!"
+    fi
+}
+
+# TODO(gleber): Compatibility mode until JBH is ugraded.
+DADE_DEVENV_DIR="${DADE_DEVENV_DIR:-${DADE_BASE:-}}"
+if [ -z "$DADE_DEVENV_DIR" ]; then
+    DADE_DEVENV_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+fi
+export DADE_DEVENV_DIR="${DADE_DEVENV_DIR}"
+export DADE_REPO_ROOT="${DADE_REPO_ROOT:-${DADE_DEVENV_DIR}/..}"
+
+# If used from another repository, DADE_VAR_DIR should already point to a
+# mutable `var/` directory to store gc-roots.
+DADE_VAR_DIR="${DADE_VAR_DIR:-$DADE_DEVENV_DIR/var}"
+DADE_NIXPKGS="${DADE_VAR_DIR}/gc-roots/nixpkgs-snapshot"
+
+# shellcheck source=./ensure-nix
+source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
+
+# In a sub-shell, source in the nix-profile and preload nixpkgs-snapshot.
+(
+  # shellcheck source=./ensure-nix
+  source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
+
+  : "${DADE_DESIRED_NIX_VERSION:=2 1 3}"
+  check_nix_version $DADE_DESIRED_NIX_VERSION
+
+  # If the user has no channels configured, then NIX_PATH might point
+  # to non-existing location. Add a backup snapshot to use as fallback
+  # for the bootstrapping.
+  export NIX_PATH=${NIX_PATH:+$NIX_PATH:}nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.03.tar.gz
+
+  # Load nixpkgs-snapshot.
+  hashfile="${DADE_NIXPKGS}.hash"
+  currentHash="$(nix-hash "$DADE_DEVENV_DIR/../nix/nixpkgs.nix")"
+  test -e "$hashfile" && hash="$(cat "$hashfile")"
+  if [[ ! -e "$DADE_NIXPKGS" || "$hash" != "$currentHash" ]]; then
+    errcho "Loading outdated or missing nixpkgs snapshot..."
+    outpath="$(
+      nix-store -Q --realise --indirect --add-root "$DADE_NIXPKGS" \
+        "$(nix-instantiate -Q --eval "${DADE_DEVENV_DIR}/../nix/nixpkgs.nix" -A path \
+          | sed 's/^\"//;s/\"$//')"
+    )"
+    printf "$currentHash" >| "$hashfile"
+    errcho "Done loading the nixpkgs snapshot to $outpath"
+  fi
+)
+
+# Make sure nix gets ensured in main shell
+echo source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
+
+# Expose our tools in /dev-env/bin and our version of nixpkgs
+echo "export NIX_CONF_DIR=\"${DADE_DEVENV_DIR}/etc\""
+echo "export NIX_PATH=nixpkgs=\"${DADE_NIXPKGS}\""
+echo "export PATH=\"${DADE_DEVENV_DIR}/bin:\$PATH\""
+echo "export PYTHONPATH=\".\${PYTHONPATH:+:\$PYTHONPATH}\""
+echo "export DADE_REPO_ROOT=${DADE_REPO_ROOT}"
+echo "export DADE_VAR_DIR=${DADE_VAR_DIR}"
+echo "export DADE_DEVENV_DIR=${DADE_DEVENV_DIR}"
+
+# Make sure the locale is UTF-8 capable. Setting LOCALE_ARCHIVE is
+# necessary on Ubuntu (but not on CentOS) to make the Nix glibc find
+# the en_US.UTF-8 locale (DEL-2851).
+if [[ $(uname -v) =~ 'Ubuntu' ]]; then
+    # If the user has no channels configured, then NIX_PATH might point
+    # to non-existing location. Add a backup snapshot to use as fallback
+    # for the bootstrapping.
+    TMP_NIX_PATH=nixpkgs=${DADE_NIXPKGS}
+
+    # since we need to set LC_ALL=C to prevent any messages about missing locale
+    # until we fetch the locale, we start in a separate shell
+    (
+        export LC_ALL=C
+        unset NIX_PATH
+        out=$(nix-build --no-out-link -Q "${DADE_DEVENV_DIR}/../nix" -I "${TMP_NIX_PATH}" -A pkgs.glibcLocales)
+        echo "export LOCALE_ARCHIVE=\"${out}/lib/locale/locale-archive\""
+    )
+fi
+echo "export LC_ALL=en_US.UTF-8"
+echo "export LANG=en_US.UTF-8"
+

--- a/dev-env/lib/dade-exec-nix-bin-tool
+++ b/dev-env/lib/dade-exec-nix-bin-tool
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Meant to be linked to from `dev-env/bin`, symlink should be named after the
+# tool. Execute a Nix tool from a derivation that creates a `result-bin`
+# directory.
+
+DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
+base=$(basename $0)
+execTool $base bin $base "$@"

--- a/dev-env/lib/dade-exec-nix-tool
+++ b/dev-env/lib/dade-exec-nix-tool
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Meant to be linked to from `dev-env/bin`, symlink should be named after the
+# tool. Execute a Nix tool from a derivation that creates a `result` directory.
+
+DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
+base=$(basename $0)
+execTool $base out $base "$@"

--- a/dev-env/lib/ensure-nix
+++ b/dev-env/lib/ensure-nix
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# source this file to check that nix is installed
+#
+# if nix is installed as a user profile, it will also load the nix profile
+
+ensure_nix() {
+  local nix_profile=$HOME/.nix-profile/etc/profile.d/nix.sh
+  if type -p nix &>/dev/null; then
+    return
+  fi
+
+  # shellcheck disable=SC1090
+  [[ -f "$nix_profile" ]] && source "$nix_profile"
+
+  if type -p nix &>/dev/null; then
+    return
+  fi
+
+  echo "[dev-env] Nix is not installed on your machine." >&2
+  echo "[dev-env] Run \`bash <(curl -sSfL https://nixos.org/nix/install)\`" >&2
+  return 1
+}
+
+: "${MANPATH:=}" # Nix 2.x profile fails if `set -e` is active otherwise.
+ensure_nix || exit 1

--- a/dev-env/profile_bash.sh
+++ b/dev-env/profile_bash.sh
@@ -1,0 +1,4 @@
+# DADE shell profile for bash
+
+export DADE_REPO_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}")/.. ; pwd)"
+source /dev/stdin <<< "$(${DADE_REPO_ROOT}/dev-env/bin/dade assist)"

--- a/dev-env/profile_zsh.sh
+++ b/dev-env/profile_zsh.sh
@@ -1,0 +1,3 @@
+# DADE shell profile compatible with zsh.
+
+source <("${0:A:h}"/bin/dade assist)

--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -34,7 +34,7 @@ data "google_compute_subnetwork" "subnet" {
 
 resource "google_compute_firewall" "allow-internal" {
   name    = "allow-internal"
-  network = "${data.google_compute_network.network.self_link}"
+  network = data.google_compute_network.network.self_link
   allow {
     protocol = "tcp"
   }
@@ -44,12 +44,12 @@ resource "google_compute_firewall" "allow-internal" {
   allow {
     protocol = "icmp"
   }
-  source_ranges = ["${data.google_compute_subnetwork.subnet.ip_cidr_range}"]
+  source_ranges = [data.google_compute_subnetwork.subnet.ip_cidr_range]
 }
 
 resource "google_compute_firewall" "allow-http-load-balancers" {
   name    = "allow-lb"
-  network = "${data.google_compute_network.network.self_link}"
+  network = data.google_compute_network.network.self_link
   allow {
     protocol = "tcp"
     ports    = ["80", "8080", "8081"]
@@ -85,8 +85,8 @@ resource "google_compute_instance" "backed-up-db" {
   }
 
   network_interface {
-    network    = "${data.google_compute_network.network.self_link}"
-    subnetwork = "${data.google_compute_subnetwork.subnet.self_link}"
+    network    = data.google_compute_network.network.self_link
+    subnetwork = data.google_compute_subnetwork.subnet.self_link
     access_config {
       // auto-generate ephemeral IP
     }
@@ -174,8 +174,8 @@ resource "google_compute_instance" "ledger" {
   }
 
   network_interface {
-    network    = "${data.google_compute_network.network.self_link}"
-    subnetwork = "${data.google_compute_subnetwork.subnet.self_link}"
+    network    = data.google_compute_network.network.self_link
+    subnetwork = data.google_compute_subnetwork.subnet.self_link
     access_config {
       // auto-generate ephemeral IP
     }
@@ -260,8 +260,8 @@ resource "google_compute_instance" "proxy" {
   }
 
   network_interface {
-    network    = "${data.google_compute_network.network.self_link}"
-    subnetwork = "${data.google_compute_subnetwork.subnet.self_link}"
+    network    = data.google_compute_network.network.self_link
+    subnetwork = data.google_compute_subnetwork.subnet.self_link
     access_config {
       // auto-generate ephemeral IP
     }
@@ -305,7 +305,7 @@ resource "google_compute_address" "proxy" {
 // machine.
 resource "google_compute_instance_group" "frontend" {
   name      = "frontend"
-  instances = ["${google_compute_instance.proxy.self_link}"]
+  instances = [google_compute_instance.proxy.self_link]
   named_port {
     name = "http"
     port = "8081"
@@ -403,30 +403,30 @@ resource "google_compute_http_health_check" "frontend" {
 // they get redirected by nginx to HTTPS on port 443.
 resource "google_compute_forwarding_rule" "frontend" {
   name         = "frontend"
-  target       = "${google_compute_target_http_proxy.frontend.self_link}"
-  ip_address   = "${google_compute_address.proxy.address}"
+  target       = google_compute_target_http_proxy.frontend.self_link
+  ip_address   = google_compute_address.proxy.address
   port_range   = "80"
   network_tier = "STANDARD"
 }
 
 resource "google_compute_target_http_proxy" "frontend" {
   name    = "frontend"
-  url_map = "${google_compute_url_map.frontend.self_link}"
+  url_map = google_compute_url_map.frontend.self_link
 }
 
 resource "google_compute_url_map" "frontend" {
   name            = "frontend"
-  default_service = "${google_compute_backend_service.frontend.self_link}"
+  default_service = google_compute_backend_service.frontend.self_link
 }
 
 resource "google_compute_backend_service" "frontend" {
   provider        = google-beta
   name            = "frontend"
-  health_checks   = ["${google_compute_http_health_check.frontend.self_link}"]
-  security_policy = "${google_compute_security_policy.only-offices-and-vpns.self_link}"
+  health_checks   = [google_compute_http_health_check.frontend.self_link]
+  security_policy = google_compute_security_policy.only-offices-and-vpns.self_link
   port_name       = "http"
   backend {
-    group = "${google_compute_instance_group.frontend.self_link}"
+    group = google_compute_instance_group.frontend.self_link
   }
   log_config {
     enable      = true
@@ -438,31 +438,31 @@ resource "google_compute_backend_service" "frontend" {
 // address to port 80 of the machine (after TLS termination)
 resource "google_compute_forwarding_rule" "ui" {
   name         = "ui"
-  target       = "${google_compute_target_https_proxy.ui.self_link}"
-  ip_address   = "${google_compute_address.proxy.address}"
+  target       = google_compute_target_https_proxy.ui.self_link
+  ip_address   = google_compute_address.proxy.address
   port_range   = "443"
   network_tier = "STANDARD"
 }
 
 resource "google_compute_target_https_proxy" "ui" {
   name             = "ui"
-  url_map          = "${google_compute_url_map.ui.self_link}"
+  url_map          = google_compute_url_map.ui.self_link
   ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/da-dev-pinacolada/global/sslCertificates/da-ext-wildcard"]
 }
 
 resource "google_compute_url_map" "ui" {
   name            = "ui"
-  default_service = "${google_compute_backend_service.ui.self_link}"
+  default_service = google_compute_backend_service.ui.self_link
 }
 
 resource "google_compute_backend_service" "ui" {
   provider        = google-beta
   name            = "ui"
-  health_checks   = ["${google_compute_http_health_check.frontend.self_link}"]
-  security_policy = "${google_compute_security_policy.only-offices-and-vpns.self_link}"
+  health_checks   = [google_compute_http_health_check.frontend.self_link]
+  security_policy = google_compute_security_policy.only-offices-and-vpns.self_link
   port_name       = "https"
   backend {
-    group = "${google_compute_instance_group.frontend.self_link}"
+    group = google_compute_instance_group.frontend.self_link
   }
   log_config {
     enable      = true
@@ -480,30 +480,30 @@ resource "google_compute_backend_service" "ui" {
 // 443.
 resource "google_compute_forwarding_rule" "navigator" {
   name         = "navigator"
-  target       = "${google_compute_target_http_proxy.navigator.self_link}"
-  ip_address   = "${google_compute_address.proxy.address}"
+  target       = google_compute_target_http_proxy.navigator.self_link
+  ip_address   = google_compute_address.proxy.address
   port_range   = "8080"
   network_tier = "STANDARD"
 }
 
 resource "google_compute_target_http_proxy" "navigator" {
   name    = "navigator"
-  url_map = "${google_compute_url_map.navigator.self_link}"
+  url_map = google_compute_url_map.navigator.self_link
 }
 
 resource "google_compute_url_map" "navigator" {
   name            = "navigator"
-  default_service = "${google_compute_backend_service.navigator.self_link}"
+  default_service = google_compute_backend_service.navigator.self_link
 }
 
 resource "google_compute_backend_service" "navigator" {
   provider        = google-beta
   name            = "navigator"
-  health_checks   = ["${google_compute_http_health_check.frontend.self_link}"]
-  security_policy = "${google_compute_security_policy.only-offices-and-vpns.self_link}"
+  health_checks   = [google_compute_http_health_check.frontend.self_link]
+  security_policy = google_compute_security_policy.only-offices-and-vpns.self_link
   port_name       = "navigator"
   backend {
-    group = "${google_compute_instance_group.frontend.self_link}"
+    group = google_compute_instance_group.frontend.self_link
   }
   log_config {
     enable      = true
@@ -512,5 +512,5 @@ resource "google_compute_backend_service" "navigator" {
 }
 
 output "proxy-ip" {
-  value = "${google_compute_address.proxy.address}"
+  value = google_compute_address.proxy.address
 }

--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -14,14 +14,12 @@ provider "google" {
   project = "da-dev-pinacolada"
   region  = "us-east4"
   zone    = "us-east4-a"
-  version = "2.17.0"
 }
 
 provider "google-beta" {
   project = "da-dev-pinacolada"
   region  = "us-east4"
   zone    = "us-east4-a"
-  version = "2.17.0"
 }
 
 # Network created by the security team. Allows all traffic from offices and

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,33 @@
+{ system ? builtins.currentSystem }:
+
+let
+  pkgs = import ./nixpkgs.nix { inherit system; };
+
+  # Selects "bin" output from multi-output derivations which are has it. For
+  # other multi-output derivations, select only the first output. For
+  # single-output generation, do nothing.
+  #
+  # This ensures that as few output as possible of the tools we use below are
+  # realized by Nix.
+  selectBin = pkg:
+    if pkg == null then
+      null
+    else if builtins.hasAttr "bin" pkg then
+      pkg.bin
+    else if builtins.hasAttr "outputs" pkg then
+      builtins.getAttr (builtins.elemAt pkg.outputs 0) pkg
+    else
+      pkg;
+
+in rec {
+  inherit pkgs;
+  tools = pkgs.lib.mapAttrs (_: pkg: selectBin pkg) (rec {
+
+    # Cloud tools
+    terraform = pkgs.terraform.withPlugins (p: with p; [
+      google
+      google-beta
+    ]);
+  });
+
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,16 @@
+# Pinned version of nixpkgs that we use for our development and deployment.
+
+{ system ? builtins.currentSystem, ... }:
+
+let
+  # See ./nixpkgs/README.md for upgrade instructions.
+  src = import ./nixpkgs;
+
+  nixpkgs = import src {
+    inherit system;
+
+    config.allowUnfree = true;
+    config.allowBroken = true;
+  };
+in
+  nixpkgs

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,0 +1,8 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./default.src.json);
+  src = builtins.fetchTarball {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
+  };
+in
+  src

--- a/nix/nixpkgs/default.src.json
+++ b/nix/nixpkgs/default.src.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs-channels",
+  "branch": "nixpkgs-unstable",
+  "rev": "1facbd61b179670e6ce6945957c83bf345ddb1b4",
+  "sha256": "1sd6wm8is9qwnvwpzc3wwvzsln865d3zzll8p0f0d74lil69ii50"
+}


### PR DESCRIPTION
I got mildly annoyed at having to #259 again, and then @cocreature pushed me over the edge, so here is a proper fix.

Note: this only include Terraform in the dev-env for now, but we should probably look at expanding that over time.

This also means Terraform gets bumped again, to 0.12.28, because I was too lazy to hunt down the latest nixpkgs snapshot that still included 0.12.26, so instead I just picked the latest one.

Also note that nix-bundled Terraform comes with its embedded plugins, which do not have a version string, so we need to remove the version requirement from the tf file.