### PR TITLE
rebuild UI image on deps change

### DIFF
--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -98,7 +98,7 @@ else
     tell_slack json-api:$JSON_API_TAG
 fi
 
-UI_TAG=$(get_tag ui docker/nginx.docker docker/nginx.conf.sh)
+UI_TAG=$(get_tag ui docker/nginx.docker docker/nginx.conf.sh yarn.lock)
 if tag_exists ui $UI_TAG; then
     echo "ui $UI_TAG already exists."
 else


### PR DESCRIPTION
Adding the yarn.lock file ensures we keep the dependencies in production in line with the dependencies in the repo.