### PR TITLE
shut down everything

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,6 +187,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
           IS_MASTER: $(is_master)
         displayName: deploy
+        condition: false
 
       - bash: |
           set -euo pipefail


### PR DESCRIPTION
We have found an issue with the 1.6RC. We want to test the new 1.6RC
that fixes that issue, but that requires resetting the DB. Here is the
plan:

1. Shut down the entire system. (This PR.)
2. Manually muck around in the GCS bucket with hourly backups. We
   currently have a flat `$(date).gz` set of files, which is a bit
   cumbersome. Also, I'd like to avoid unecessarily losing data if we can,
   so deleting the post-1.6RC2 backups seems wasteful. So I've come up
   with this scheme for backups from now on: change the path to
   `/r0/$(date).gz` for the existing ones (where `r` stands for database
   restores), and then create a new hierarchy
   `/r1/$(year)/$(month)/$(day)/$(date).gz` for future backups, and
   manually copy the backup we want to start from there
   (`20201012090001Z`). That way we keep track of where we stopped and
   when we started again.
3. Update the tf files to reflect the new db structure and revert to the
   prior images (i.e. revert #269 and #270). Deploy that. Hope it all
   works out.
4. Upgrade to 1.6RC3.