### PR TITLE
tweak CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   - job: build_and_test
     timeoutInMinutes: 120
     pool:
-      vmImage: "Ubuntu-16.04"
+      vmImage: "Ubuntu-20.04"
     variables:
       is_master: $[ eq(variables['Build.SourceBranch'], 'refs/heads/master') ]
     steps:
@@ -118,6 +118,11 @@ jobs:
               return $result
           }
 
+          current_commit_matches_deployment () {
+              # returns 0 if no changes to apply, 1 on error and 2 if changes
+              terraform plan -detailed-exitcode -var-file=deployed-versions.tfvars
+          }
+
           current_commit_changes_infra () {
               # returns 0 if output is non-empty, i.e. if there is at least one
               # file in the infra folder that changed (besides the
@@ -158,6 +163,10 @@ jobs:
             exit 0
           fi
 
+          if current_commit_matches_deployment; then
+            echo "Nothing to do, HEAD matches deployment."
+            exit 0
+          fi
           if previous_commit_reflects_deployment; then
               if current_commit_changes_infra; then
                   tell_slack "<!here> *WARNING*: Latest commit changes infra. Please apply manually."
@@ -169,7 +178,7 @@ jobs:
                           # There is a race condition whereby the ui server
                           # gets removed from the load balancing pool if its
                           # name has not changed. Applying the same file again
-                          # gets Terraform to notice and correc tthe
+                          # gets Terraform to notice and correct the
                           # inconsistency. This is not the most elegant way to
                           # solve it, but should work for now.
                           terraform apply -auto-approve -var-file=deployed-versions.tfvars


### PR DESCRIPTION
- Bump agent version, because 16.04 gets dropped in September.
- Don't freak out if current commit is already deployed.